### PR TITLE
Update acf.php

### DIFF
--- a/inc/acf/acf.php
+++ b/inc/acf/acf.php
@@ -15,9 +15,7 @@ function mitypes_is_acf_loaded(){
     include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
     
     if (
-        ( ! is_plugin_active( 'advanced-custom-fields/acf.php'     ) ) &&
-        ( ! is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) )
-
+        ( ! class_exists( 'ACF' ) )
     ){
 
         return false ;


### PR DESCRIPTION
Just a suggestion - but feel free to ignore it, as you may have done this for a reason.
But, maybe check if ACF is active via the class name; as some people put ACF in the must-use folder (or vendor folder),
which is ignored by 'is_plugin_active'.